### PR TITLE
Add git binaries

### DIFF
--- a/com.github.Murmele.Gittyup.yml
+++ b/com.github.Murmele.Gittyup.yml
@@ -45,6 +45,16 @@ modules:
         version-query: .tag_name | sub("^[vV]";"")
         url-query: .assets[] | select(.label=="Source") | .browser_download_url
 
+  - name: git
+    buildsystem: simple
+    build-commands:
+    - install -Dm755 $(which git) ${FLATPAK_DEST}/bin/
+    - install -Dm755 $(which git-cvsserver) ${FLATPAK_DEST}/bin/
+    - install -Dm755 $(which git-receive-pack) ${FLATPAK_DEST}/bin/
+    - install -Dm755 $(which git-shell) ${FLATPAK_DEST}/bin/
+    - install -Dm755 $(which git-upload-archive) ${FLATPAK_DEST}/bin/
+    - install -Dm755 $(which git-upload-pack) ${FLATPAK_DEST}/bin/
+
   - name: Gittyup
     buildsystem: cmake-ninja
     config-opts: ["-DFLATPAK=ON"]


### PR DESCRIPTION
Flatpak requires Git to operate, and it can be safely assumed it exists for either copying or linking. I don't know the policies regarding linking binaries, but if possible, I'd use linking to keep the version of Git used by Gittyup current by using the system binaries.