### PR TITLE
Switch git-lfs to precompiled binaries

### DIFF
--- a/com.github.Murmele.Gittyup.yml
+++ b/com.github.Murmele.Gittyup.yml
@@ -2,8 +2,6 @@ app-id: com.github.Murmele.Gittyup
 runtime: org.kde.Platform
 runtime-version: 5.15-21.08
 sdk: org.kde.Sdk
-sdk-extensions:
-  - org.freedesktop.Sdk.Extension.golang # //21.08 # to be able to install git-lfs
 command: gittyup
 desktop-file-name-suffix: "" # used to create development version
 finish-args:
@@ -13,7 +11,7 @@ finish-args:
   - --share=network
   - --share=ipc
   - --filesystem=home
-  - --filesystem=/tmp # Needed to store temporary files, which should be opened by external (non sandboxed) applications like kdiff3. Did not find another way to share a temporary file to the host (only creating a tmp folder in the home folder, I don't like) 
+  - --filesystem=/tmp # Needed to store temporary files, which should be opened by external (non sandboxed) applications like kdiff3. Did not find another way to share a temporary file to the host (only creating a tmp folder in the home folder, I don't like)
   # we use the keyring to store credentials
   - --filesystem=xdg-run/keyring
   # for git repos that require ssh keys
@@ -30,23 +28,32 @@ build-options:
 
 modules:
   - name: git-lfs
-    build-options:
-      env:
-        GO111MODULE: on
-        GOFLAGS: -mod=vendor
     buildsystem: simple
     build-commands:
-      - go build -v -o ./bin/git-lfs ./git-lfs.go
-      - install -Dm755 -t ${FLATPAK_DEST}/bin/ ./bin/git-lfs
+      - PREFIX=${FLATPAK_DEST} ./install.sh
     sources:
       - type: archive
-        url: https://github.com/git-lfs/git-lfs/releases/download/v3.2.0/git-lfs-v3.2.0.tar.gz
-        sha256: f8e6bbe043b97db8a5c16da7289e149a3fed9f4d4f11cffcc6e517c7870cd9e5
+        strip-components: 1
+        url: https://github.com/git-lfs/git-lfs/releases/download/v3.3.0/git-lfs-linux-amd64-v3.3.0.tar.gz
+        sha256: 6a4e6bd7d06d5c024bc70c8ee8c9da143ffc37d2646e252a17a6126d30cdebc1
+        only-arches: [x86_64]
         x-checker-data:
           type: json
           url: https://api.github.com/repos/git-lfs/git-lfs/releases/latest
-          version-query: .tag_name | sub("^[vV]";"")
-          url-query: .assets[] | select(.label=="Source") | .browser_download_url
+          url-query: .assets[] | select(.name=="git-lfs-linux-amd64-" + $version +
+            ".tar.gz") | .browser_download_url
+          version-query: .tag_name
+      - type: archive
+        strip-components: 1
+        url: https://github.com/git-lfs/git-lfs/releases/download/v3.3.0/git-lfs-linux-arm64-v3.3.0.tar.gz
+        sha256: e97c477981a9b6a40026cadc1bf005541d973fc32df2de2f398643b15df6b5c6
+        only-arches: [aarch64]
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/git-lfs/git-lfs/releases/latest
+          url-query: .assets[] | select(.name=="git-lfs-linux-arm64-" + $version +
+            ".tar.gz") | .browser_download_url
+          version-query: .tag_name
 
   - name: git
     buildsystem: simple


### PR DESCRIPTION
Closes https://github.com/flathub/com.github.Murmele.Gittyup/pull/32
Closes https://github.com/flathub/com.github.Murmele.Gittyup/pull/29
Closes https://github.com/flathub/com.github.Murmele.Gittyup/pull/25
Closes https://github.com/flathub/com.github.Murmele.Gittyup/pull/23

It's no longer possible to build it from source. Seems like go tries to always pull the modules specified from the repo which isn't possible because flathub builders don't have network access.