### PR TITLE
Update KDE runtime and SDK to 5.15-23.08

### DIFF
--- a/com.github.Murmele.Gittyup.yml
+++ b/com.github.Murmele.Gittyup.yml
@@ -1,6 +1,6 @@
 app-id: com.github.Murmele.Gittyup
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-23.08
 sdk: org.kde.Sdk
 command: gittyup
 desktop-file-name-suffix: "" # used to create development version


### PR DESCRIPTION
Since [a Qt 6 build PR is open](https://github.com/flathub/com.github.Murmele.Gittyup/pull/37) [but is currently blocked](https://github.com/flathub/com.github.Murmele.Gittyup/issues/39#issuecomment-1846118852), _this_ PR _should_ update the underlying FDO runtime to a currently non-EOL version, so that (as of the moment this PR goes live, at least) the runtime can still be considered active and up-to-date while still using Qt 5 to build Gittyup (hopefully successfully).

Fixes #39